### PR TITLE
Fix ordering so that it runs after the minifier

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,15 @@
+NPOSL-3.0
+
+vite-plugin-javascript-obfuscator-generate-bundle: (C) 2024 Wilson Foo Yu Kang. All rights reserved except as expressly set out hereinafter.
+Unrestricted sole licence granted to Custom Automated Systems (R) Pte Ltd, revocable with express written notice by Wilson Foo Yu Kang.
+
+Dual licensed under:
+NPOSL-3.0 https://opensource.org/licenses/NPOSL-3.0
+Proprietary sub-licence with Custom Automated Systems Pte Ltd (contact sales@customautosys.com to negotiate licence terms)
+
 MIT License
 
-Copyright (c) 2022 elmeet
+vite-plugin-javascript-obfuscator: Copyright (c) 2022 elmeet
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# vite-plugin-javascript-obfuscator
+# vite-plugin-javascript-obfuscator-generate-bundle
 
-A Vite Plugin for [javascript-obfuscator](https://www.npmjs.com/package/javascript-obfuscator)
+A Vite Plugin for [javascript-obfuscator](https://www.npmjs.com/package/javascript-obfuscator) which uses the generateBundle hook instead
 
 ## Installation
 
 Install the package:
 
-- npm `npm install --save-dev vite-plugin-javascript-obfuscator`
-- yarn `yarn add --dev vite-plugin-javascript-obfuscator`
-- pnpm `pnpm i vite-plugin-javascript-obfuscator -D`
+- npm `npm install --save-dev vite-plugin-javascript-obfuscator-generate-bundle`
+- yarn `yarn add --dev vite-plugin-javascript-obfuscator-generate-bundle`
+- pnpm `pnpm i vite-plugin-javascript-obfuscator-generate-bundle -D`
 
 ## Usage
 
@@ -17,7 +17,7 @@ Install the package:
 vite.config.js
 
 ```javascript
-import obfuscatorPlugin from "vite-plugin-javascript-obfuscator";
+import obfuscatorPlugin from "vite-plugin-javascript-obfuscator-generate-bundle";
 
 export default defineConfig({
   plugins: [
@@ -37,7 +37,7 @@ export default defineConfig({
 vite.config.js
 
 ```javascript
-import obfuscatorPlugin from "vite-plugin-javascript-obfuscator";
+import obfuscatorPlugin from "vite-plugin-javascript-obfuscator-generate-bundle";
 
 export default defineConfig({
   plugins: [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "vite-plugin-javascript-obfuscator",
-  "version": "3.1.0",
+  "name": "vite-plugin-javascript-obfuscator-generate-bundle",
+  "version": "3.1.1",
   "description": "A Vite Plugin for javascript-obfuscator",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/elmeet/vite-plugin-javascript-obfuscator.git"
+    "url": "git+https://github.com/customautosys/vite-plugin-javascript-obfuscator-generate-bundle.git"
   },
   "keywords": [
     "vite",
@@ -23,12 +23,12 @@
     "javascript obfuscator",
     "js obfuscator"
   ],
-  "author": "elmeet@163.com",
+  "author": "customautosys@163.com",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/elmeet/vite-plugin-javascript-obfuscator/issues"
+    "url": "https://github.com/customautosys/vite-plugin-javascript-obfuscator-generate-bundle/issues"
   },
-  "homepage": "https://github.com/elmeet/vite-plugin-javascript-obfuscator#readme",
+  "homepage": "https://github.com/customautosys/vite-plugin-javascript-obfuscator-generate-bundle#readme",
   "dependencies": {
     "anymatch": "~3.1.3",
     "javascript-obfuscator": "^4.1.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,18 +68,18 @@ export default function obfuscatorPlugin(obOptions?: Options) {
     : defaultExcludeMatcher;
 
   return <Plugin>{
-    name: "vite-plugin-javascript-obfuscator",
+    name: "vite-plugin-javascript-obfuscator-generate-bundle",
     enforce: "post" as "post",
     apply: obOptions?.apply || (() => true),
     generateBundle(outputOptions: NormalizedOutputOptions, bundle: OutputBundle) {
       for(let fileName in bundle){
         if (anymatch(excludeMatcher, fileName, { dot: true })) {
-          consoleLog("[::plugin-javascript-obfuscator]::exclude", fileName);
+          consoleLog("[::plugin-javascript-obfuscator-generate-bundle]::exclude", fileName);
           return;
         }
 
         if (anymatch(includeMatcher, fileName) && bundle[fileName].type==='chunk') {
-          consoleLog("[::plugin-javascript-obfuscator]::include matched", fileName);
+          consoleLog("[::plugin-javascript-obfuscator-generate-bundle]::include matched", fileName);
 
           const obfuscationResult = obfuscate((bundle[fileName] as OutputChunk).code, options);
 
@@ -101,7 +101,7 @@ export default function obfuscatorPlugin(obOptions?: Options) {
           });
         }
 
-        consoleLog(`[::plugin-javascript-obfuscator]::not matched`, fileName);
+        consoleLog(`[::plugin-javascript-obfuscator-generate-bundle]::not matched`, fileName);
       }
     }
   };


### PR DESCRIPTION
Dear @elmeet,

I would like to suggest the use of the generateBundle hook instead. This is so that the obfuscation will run after the minifier.

https://github.com/elmeet/vite-plugin-javascript-obfuscator/issues/13#issuecomment-2066910052

However, 1 drawback (which I haven't figured out how to solve yet but I believe there will be a solution) is there currently doesn't seem to be a way to add the sourceMap to emitFile (which has to emit the file as an asset).

I have tested and it is working to obfuscate the code even when the minifier is esbuild. 